### PR TITLE
Roll docker/build-push-action back to 1.1.0

### DIFF
--- a/.github/workflows/build-container-image.yaml
+++ b/.github/workflows/build-container-image.yaml
@@ -22,13 +22,13 @@ jobs:
         uses: actions/checkout@v2.3.4
 
       - name: Build the container image
-        uses: docker/build-push-action@v1.1.1
+        uses: docker/build-push-action@v1.1.0
         with:
           repository: cloudability-api
 
       - name: Tag and push the image
         if: github.event_name == 'push' || github.event_name == 'release'
-        uses: docker/build-push-action@v1.1.1
+        uses: docker/build-push-action@v1.1.0
         with:
           repository: ${{ github.repository_owner }}/cloudability-api
           registry: ghcr.io


### PR DESCRIPTION
I am not planning to use v2 and I don't want to see the deprecation message anymore.